### PR TITLE
Add --ignore-garbage option into base64 command.

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -34,7 +34,7 @@ commands:
     steps:
       - run:
           name: Store Google Service Account
-          command: echo ${<< parameters.service_account_key >>} | base64 --decode > ${HOME}/gcloud-service-key.json
+          command: echo ${<< parameters.service_account_key >>} | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
       - run:
           name: Authorize gcloud and set config defaults
           command: |


### PR DESCRIPTION
I found error below in my project.
I thought that the Base64 text created with some base64 encoders can not decode correctly.

#### `Store Google Service Account`
```
#!/bin/bash -eo pipefail
echo ${GOOGLE_SERVICES_JSON} | base64 --decode > ${HOME}/gcloud-service-key.json
base64: invalid input
Exited with code 1
```